### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,32 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # jasper
+
+Static HTML pages describing the drug development pipeline.
+
+## GitHub Pages
+
+The site is published with GitHub Pages. Pushing changes to `main`
+triggers a GitHub Actions workflow that deploys the contents of
+the repository to GitHub Pages.
+
+After the workflow runs, the site will be available at `https://<username>.github.io/jasper/` (replace `<username>` with the GitHub account that owns this repository).


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy static site to GitHub Pages
- update documentation with GitHub Pages details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68955c93b8908327a8ed0ef2238021c5